### PR TITLE
Make plugin dependency free

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,18 +4,30 @@
  */
 'use strict'
 
+const fs = require('fs')
+const path = require('path')
+
 //------------------------------------------------------------------------------
-// Requirements
+// Helpers
 //------------------------------------------------------------------------------
 
-const requireIndex = require('requireindex')
+const loadRules = () => {
+  const rules = {}
+  const dirPath = `${__dirname}/rules`
+  fs.readdirSync(dirPath).forEach((filename) => {
+    const filepath = path.resolve(path.join(dirPath, filename))
+    const basename = path.basename(filename, '.js')
+    rules[basename] = require(filepath)
+  })
+  return rules
+}
 
 //------------------------------------------------------------------------------
 // Plugin Definition
 //------------------------------------------------------------------------------
 
 // import all rules in lib/rules
-module.exports.rules = requireIndex(__dirname + '/rules')
+module.exports.rules = loadRules()
 
 module.exports.configs = {
   recommended: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-ternary",
-  "version": "1.0.0",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -44,9 +44,9 @@
       }
     },
     "@eslint/eslintrc": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.1.3.tgz",
-      "integrity": "sha512-4YVwPkANLeNtRjMekzux1ci8hIaH5eGKktGqR0d3LWsKNn5B2X/1Z6Trxy7jQXl9EBGE6Yj02O+t09FMeRllaA==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.2.0.tgz",
+      "integrity": "sha512-+cIGPCBdLCzqxdtwppswP+zTsH9BOIGzAeKfBIbtb4gW/giMlfMwP0HUSFfhzh20f9u8uZ8hOp62+4GPquTbwQ==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
@@ -371,13 +371,13 @@
       "dev": true
     },
     "eslint": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.11.0.tgz",
-      "integrity": "sha512-G9+qtYVCHaDi1ZuWzBsOWo2wSwd70TXnU6UHA3cTYHp7gCTXZcpggWFoUVAMRarg68qtPoNfFbzPh+VdOgmwmw==",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.12.0.tgz",
+      "integrity": "sha512-n5pEU27DRxCSlOhJ2rO57GDLcNsxO0LPpAbpFdh7xmcDmjmlGUfoyrsB3I7yYdQXO5N3gkSTiDrPSPNFiiirXA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
-        "@eslint/eslintrc": "^0.1.3",
+        "@eslint/eslintrc": "^0.2.0",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -416,9 +416,9 @@
       }
     },
     "eslint-config-prettier": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.13.0.tgz",
-      "integrity": "sha512-LcT0i0LSmnzqK2t764pyIt7kKH2AuuqKRTtJTdddWxOiUja9HdG5GXBVF2gmCTvVYWVsTu8J2MhJLVGRh+pj8w==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.14.0.tgz",
+      "integrity": "sha512-DbVwh0qZhAC7CNDWcq8cBdK6FcVHiMTKmCypOPWeZkp9hJ8xYwTaWSa6bb6cjfi8KOeJy0e9a8Izxyx+O4+gCQ==",
       "dev": true,
       "requires": {
         "get-stdin": "^6.0.0"
@@ -1143,11 +1143,6 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
-    },
-    "requireindex": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
-      "integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww=="
     },
     "resolve": {
       "version": "1.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-ternary",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Catch logical and conditional errors inside of ternary conditions.",
   "keywords": [
     "eslint",
@@ -19,12 +19,10 @@
     "lint:cli": "eslint",
     "lint:fix": "eslint --fix ."
   },
-  "dependencies": {
-    "requireindex": "^1.2.0"
-  },
+  "dependencies": {},
   "devDependencies": {
-    "eslint": "^7.1.0",
-    "eslint-config-prettier": "^6.0.13",
+    "eslint": "^7.12.0",
+    "eslint-config-prettier": "^6.14.0",
     "eslint-plugin-eslint-plugin": "^2.2.1",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.1.4",

--- a/tests/lib/rules/nesting.js
+++ b/tests/lib/rules/nesting.js
@@ -8,7 +8,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const rule = require('../../../lib/rules/nesting.js')
+const { rules } = require('../../../lib/index')
 
 const RuleTester = require('eslint').RuleTester
 const ruleTester = new RuleTester({
@@ -21,7 +21,7 @@ const ruleTester = new RuleTester({
 // Tests
 //------------------------------------------------------------------------------
 
-ruleTester.run('nesting', rule, {
+ruleTester.run('nesting', rules['nesting'], {
   valid: [
     'isMember ? 2.00 : 3.00;',
     'condition1 ? foo() : condition2 ? bar() : condition3 ? baz() : qux()',

--- a/tests/lib/rules/no-dupe.js
+++ b/tests/lib/rules/no-dupe.js
@@ -8,7 +8,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const rule = require('../../../lib/rules/no-dupe.js')
+const { rules } = require('../../../lib/index')
 
 const RuleTester = require('eslint').RuleTester
 const ruleTester = new RuleTester({
@@ -21,7 +21,7 @@ const ruleTester = new RuleTester({
 // Tests
 //------------------------------------------------------------------------------
 
-ruleTester.run('no-dupe', rule, {
+ruleTester.run('no-dupe', rules['no-dupe'], {
   valid: [
     'isMember ? 2.00 : 3.00;',
     'formula = condition && condition1 ? User.months * currentRate : User.months * oldRate',

--- a/tests/lib/rules/no-unreachable.js
+++ b/tests/lib/rules/no-unreachable.js
@@ -8,7 +8,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const rule = require('../../../lib/rules/no-unreachable')
+const { rules } = require('../../../lib/index')
 
 const RuleTester = require('eslint').RuleTester
 const ruleTester = new RuleTester({
@@ -21,7 +21,7 @@ const ruleTester = new RuleTester({
 // Tests
 //------------------------------------------------------------------------------
 
-ruleTester.run('no-unreachable', rule, {
+ruleTester.run('no-unreachable', rules['no-unreachable'], {
   valid: [
     "!user.isMember ? user.isFounder ? 'Founder' : 'Member' : 'Guest';",
     'user.isMember ? !user.isFounder ? x : y : z;',


### PR DESCRIPTION
This PR:

- removes the requireindex dependency
- updates all tests to require rule through index file, the same way eslint does
- updates dependencies